### PR TITLE
Add solution for old-roman numerals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Ruby Playground
 
-## A place to practice Ruby
+A place to practice Ruby

--- a/roman_numerals/roman_numerals.rb
+++ b/roman_numerals/roman_numerals.rb
@@ -28,25 +28,28 @@ def convert_to_roman(arabic_number)
     1 => "I",
   }
 
-roman_numeral = ""
+  #  old_roman_numerals = {
+  #   1 => "I",
+  #   5 => "V",
+  #   10 => "X",
+  #   50 => "L",
+  #   100 => "C",
+  #   500 => "D",
+  #   1000 => "M",
+  # }
 
-  if old_roman_numerals[arabic_number]
-    old_roman_numerals[arabic_number]
-  else
+  roman_numeral = ""
+
+  while arabic_number > 0
     old_roman_numerals.each do |key, value|
-      if arabic_number > key
+      if arabic_number >= key
         roman_numeral << value
         arabic_number = arabic_number - key
-        if arabic_number == 0
-          break
-        else
-          convert_to_roman(arabic_number) 
-          #Calling the method resets roman_numeral to empty string every time the program runs. Need to debug to retain value of roman_numeral   
-        end
+        break
       end
     end
-    roman_numeral
   end
+  roman_numeral
 end
 
 

--- a/roman_numerals/roman_numerals.rb
+++ b/roman_numerals/roman_numerals.rb
@@ -15,7 +15,7 @@
 #There is no Roman numeral for 0. 
   #Return nil?
   #raise error?
-
+  #return empty string?
 
 def convert_to_roman(arabic_number)
   old_roman_numerals = {
@@ -31,14 +31,22 @@ def convert_to_roman(arabic_number)
 roman_numeral = ""
 
   if old_roman_numerals[arabic_number]
-    roman_numeral << old_roman_numerals[arabic_number]
+    old_roman_numerals[arabic_number]
   else
     old_roman_numerals.each do |key, value|
       if arabic_number > key
         roman_numeral << value
         arabic_number = arabic_number - key
+        if arabic_number == 0
+          break
+        else
+          convert_to_roman(arabic_number) 
+          #Calling the method resets roman_numeral to empty string every time the program runs. Need to debug to retain value of roman_numeral   
+        end
       end
     end
+    roman_numeral
   end
-  roman_numeral
 end
+
+

--- a/roman_numerals/spec/roman_numerals_spec.rb
+++ b/roman_numerals/spec/roman_numerals_spec.rb
@@ -21,6 +21,21 @@ describe 'converting an Arabic number to a Roman numeral' do
       expect(convert_to_roman(6)).to eq "VI"
     end
 
+    it 'converts 11 to XXI' do
+      expect(convert_to_roman(11)).to eq "XI"
+    end
+
+    it 'converts 20 to XX' do
+      expect(convert_to_roman(20)).to eq "XX"
+    end
+
+    it 'converts 354 to CCCLIV' do
+      expect(convert_to_roman(354)).to eq "CCCLIIII"
+    end
+
+    it 'converts 2451 to MMCDLI' do
+      expect(convert_to_roman(2451)). to eq 'MMCCCCLI'
+    end
   end
 
   describe 'modern Roman numerals' do


### PR DESCRIPTION
Rspec tests were also updated to reflect old Roman numerals, not modern. 
